### PR TITLE
Get rid of "disabled" on fields in BasicSettings.

### DIFF
--- a/src/BasicSettings.jsx
+++ b/src/BasicSettings.jsx
@@ -30,7 +30,6 @@ function BasicSettings({ hidden, role, store }) {
             label={t("guideangle")}
             type="number"
             value={store.guideline.angle}
-            disabled={store.ratio !== "custom"}
             onChange={(e) => store.setGuidelineAngle(e.target.value)}
             slotProps={{
               input: {

--- a/src/RatiosInput.jsx
+++ b/src/RatiosInput.jsx
@@ -22,7 +22,6 @@ function RatiosInput({ store }) {
             <Input
               type="number"
               value={r}
-              disabled={store.ratio !== "custom"}
               onChange={(e) => store.setRatio(i, e.target.value)}
               style={{ marginTop: 16, width: 60 }}
             />


### PR DESCRIPTION
It feels better to arrive and see all fields working and no puzzle to solve. Instead, set the preset to "custom" whenever a preset parameter is changed (see 1074b77ec9cc0ef82cc1ef271913b796e4727282).